### PR TITLE
Make the map work with https

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,14 @@ Welcome to the html file for the "Seven Years in Tibet" map!
 <title>Seven Years in Tibet</title>
 
 <!--Link to leaflet.js-->  
-<link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
-<script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+<link rel="stylesheet" href="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+<script src="//cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
     
 <!--Link to local css file-->  
 <link rel="stylesheet" href="Files/tibet.css">
 
 <!--Link to local title font-->  
-<link href='http://fonts.googleapis.com/css?family=Architects+Daughter' rel='stylesheet' type='text/css'>
+<link href='//fonts.googleapis.com/css?family=Architects+Daughter' rel='stylesheet' type='text/css'>
 
 <!--Link to local geojson of tibet boundary-->  
 <script src="Files/mapdata/tibet.js" type="text/javascript"></script>
@@ -58,12 +58,12 @@ var y = d.getFullYear();
     
 //load map layers & attributions   
 var layers = {
-      Satellite: L.tileLayer('http://{s}.tiles.mapbox.com/v3/jeffallen.ldnef9ji/{z}/{x}/{y}.png', {
+      Satellite: L.tileLayer('//{s}.tiles.mapbox.com/v3/jeffallen.ldnef9ji/{z}/{x}/{y}.png', {
     attribution: '<b>Sources:</b> Mapbox ($y), OpenStreetMap ($z), Wikimedia Commons, Seven Years in Tibet (Harrer 1953)  | Built by <b>Jeff Allen</b>'.replace('$y', y).replace('$z', y), 
     maxZoom: 11, 
     minZoom: 6,
 }),
-      Map: L.tileLayer('http://{s}.tiles.mapbox.com/v3/jeffallen.lfmh73g6/{z}/{x}/{y}.png', {
+      Map: L.tileLayer('//{s}.tiles.mapbox.com/v3/jeffallen.lfmh73g6/{z}/{x}/{y}.png', {
     attribution: '<b>Sources:</b> Mapbox ($y), OpenStreetMap ($z), Wikimedia Commons, Seven Years in Tibet (Harrer 1953) | Built by <b>Jeff Allen</b>'.replace('$y', y).replace('$z', y), 
     maxZoom: 11, 
     minZoom: 6,


### PR DESCRIPTION
Unfortunately your great map produces mixed content errors on https. I changed the URLs so that the browser can decide which protocol to use. Warning: I have not tested if it works (but it should).